### PR TITLE
Total co2 fix

### DIFF
--- a/src/components/assessment/AssessmentStepper.vue
+++ b/src/components/assessment/AssessmentStepper.vue
@@ -186,6 +186,8 @@ export default class AssessmentStepper extends Vue {
   @Prop() becs!: string;
   @Prop() groupedMaterials!: GroupedMaterial[];
 
+  completed = false;
+
   step: Step = 1;
 
   stepPlus() {

--- a/src/models/graphql/StreamData.interface.ts
+++ b/src/models/graphql/StreamData.interface.ts
@@ -14,6 +14,10 @@ export interface StreamData {
   };
 }
 
+export interface HTTPStreamData extends ParentSpeckleObjectData {
+  __closure: { [childId: string]: 1 };
+}
+
 export interface ParentSpeckleObjectData {
   constructionCarbonA5: CarbonA5;
   id: string;

--- a/src/models/graphql/StreamData.interface.ts
+++ b/src/models/graphql/StreamData.interface.ts
@@ -1,5 +1,6 @@
 import { ProjectDataComplete } from "../newAssessment";
 import { CarbonA5 } from "../newAssessment/speckleObject.interface";
+import { SpeckleObjectComplete } from "../newAssessment";
 
 export interface StreamData {
   data: {
@@ -14,9 +15,16 @@ export interface StreamData {
   };
 }
 
-export interface HTTPStreamData extends ParentSpeckleObjectData {
+export interface HTTPStreamDataParent extends ParentSpeckleObjectData {
   __closure: { [childId: string]: 1 };
 }
+
+export interface ChildSpeckleObjectData {
+  id: string;
+  speckleType: string;
+  act: SpeckleObjectComplete;
+}
+
 
 export interface ParentSpeckleObjectData {
   constructionCarbonA5: CarbonA5;

--- a/src/models/graphql/index.ts
+++ b/src/models/graphql/index.ts
@@ -1,5 +1,5 @@
 export { StreamReferenceObjects } from "./StreamReferenceObjects.interface";
 export { StreamReferenceBranches } from "./StreamReferenceBranches.interface";
-export { StreamData } from "./StreamData.interface";
+export { StreamData, HTTPStreamDataParent } from "./StreamData.interface";
 export { ActReportData } from "./ActReportData.interface";
 export { DeleteStreamData } from "./DeleteStreamData.interface";

--- a/src/views/Assessment.vue
+++ b/src/views/Assessment.vue
@@ -334,7 +334,6 @@ export default class Assessment extends Vue {
   }
 
   calcTotals(reportObjs: SpeckleObjectComplete[]): ReportTotals {
-    console.log("reportObjs:", reportObjs);
     let A1A3 = 0;
     let A4 = 0;
     let A5Site = 0;
@@ -349,7 +348,6 @@ export default class Assessment extends Vue {
       A5Value += rd.constructionCarbonA5.value;
     });
     let totalCO2 = A1A3 + A4 + A5Value;
-    console.log("[calcTotals] totalCO2:", totalCO2);
 
     return {
       transportCarbonA4: A4,

--- a/src/views/Assessment.vue
+++ b/src/views/Assessment.vue
@@ -334,6 +334,7 @@ export default class Assessment extends Vue {
   }
 
   calcTotals(reportObjs: SpeckleObjectComplete[]): ReportTotals {
+    console.log("reportObjs:", reportObjs);
     let A1A3 = 0;
     let A4 = 0;
     let A5Site = 0;
@@ -348,6 +349,7 @@ export default class Assessment extends Vue {
       A5Value += rd.constructionCarbonA5.value;
     });
     let totalCO2 = A1A3 + A4 + A5Value;
+    console.log("[calcTotals] totalCO2:", totalCO2);
 
     return {
       transportCarbonA4: A4,

--- a/src/views/Landing.vue
+++ b/src/views/Landing.vue
@@ -91,7 +91,11 @@ import {
 } from "@/models/graphql";
 
 import { DeleteBranchInput } from "@/store";
-import { extractCo2Data } from "../views/utils/viewAssessmentUtils";
+import {
+  extractCo2Data,
+  loadParent,
+  getChildren,
+} from "../views/utils/viewAssessmentUtils";
 
 import ProjectCard from "@/components/landing/ProjectCard.vue";
 import NewAssessmentCard from "@/components/landing/NewAssessmentCard.vue";
@@ -101,6 +105,7 @@ import LandingError from "@/components/landing/LandingError.vue";
 
 import ConfirmDialog from "@/components/shared/ConfirmDialog.vue";
 import SESnackBar from "@/components/shared/SESnackBar.vue";
+import { HTTPStreamData } from "@/models/graphql/StreamData.interface";
 @Component({
   components: {
     ProjectCard,
@@ -114,7 +119,7 @@ import SESnackBar from "@/components/shared/SESnackBar.vue";
 })
 export default class Landing extends Vue {
   carbonBranches: { id: string; name: string; branchid: string }[] = [];
-  branchData: { id: string; name: string; data: StreamData }[] = [];
+  branchData: { id: string; name: string; data: HTTPStreamData }[] = [];
   token = "";
   itemsPerPage = 8;
   search = "";
@@ -231,42 +236,52 @@ export default class Landing extends Vue {
         );
       }
       // get the most recent commit and the data from that commit
-      for (let i = 0; i < this.carbonBranches.length; i++) {
-        const branchCommit = await this.$store.dispatch(
-          "getStreamCommit",
-          this.carbonBranches[i].id
-        );
-        var carbonCommit = "";
-        if (branchCommit.data.stream.branch) {
-          carbonCommit =
-            branchCommit.data.stream.branch.commits.items[0].referencedObject;
-        }
-        const branch: StreamData = await this.$store.dispatch("getBranchData", [
-          this.carbonBranches[i].id,
-          carbonCommit,
-        ]);
-        if (!Object.prototype.hasOwnProperty.call(branch, "errors")) {
-          this.branchData.push({
-            id: this.carbonBranches[i].id,
-            name: this.carbonBranches[i].name,
-            data: branch,
-          });
-        }
-      }
+      this.branchData = await Promise.all(
+        this.carbonBranches.map(async (cb) => {
+          const branchCommit = await this.$store.dispatch(
+            "getStreamCommit",
+            cb.id
+          );
+          let carbonCommit = "";
+          if (branchCommit.data.stream.branch) {
+            carbonCommit =
+              branchCommit.data.stream.branch.commits.items[0].referencedObject;
+          }
+          const parent = await loadParent(
+            this.$store.state.selectedServer.url,
+            cb.id,
+            carbonCommit,
+            this.$store.state.token.token
+          );
+          return {
+            id: cb.id,
+            name: cb.name,
+            data: parent,
+          };
+        })
+      );
       // convert the data into the format that this page needs it to be in
-      this.projects = this.branchData.map((proj) => {
-        const co2Data = extractCo2Data(proj.data).materials;
+      this.projects = await Promise.all(
+        this.branchData.map(async (proj) => {
+          const childrenData = await getChildren(
+            this.$store.state.selectedServer.url,
+            this.$store.state.token.token,
+            proj.id,
+            proj.data
+          );
+          const co2Data = extractCo2Data(proj.data, childrenData).materials;
 
-        const projName = proj.data.data.stream.object.data.projectData.name;
-        return {
-          title: `${projName} - ${proj.name}`,
-          id: `${proj.id}`,
-          co2Values: co2Data,
-          totalCO2e: proj.data.data.stream.object.data.totalCO2,
-          link: "",
-          category: proj.data.data.stream.object.data.projectData.components,
-        };
-      });
+          const projName = proj.data.projectData.name;
+          return {
+            title: `${projName} - ${proj.name}`,
+            id: `${proj.id}`,
+            co2Values: co2Data,
+            totalCO2e: proj.data.totalCO2,
+            link: "",
+            category: proj.data.projectData.components,
+          };
+        })
+      );
 
       this.loading = false;
     } catch (err) {

--- a/src/views/Landing.vue
+++ b/src/views/Landing.vue
@@ -105,7 +105,7 @@ import LandingError from "@/components/landing/LandingError.vue";
 
 import ConfirmDialog from "@/components/shared/ConfirmDialog.vue";
 import SESnackBar from "@/components/shared/SESnackBar.vue";
-import { HTTPStreamData } from "@/models/graphql/StreamData.interface";
+import { HTTPStreamDataParent } from "@/models/graphql/";
 @Component({
   components: {
     ProjectCard,
@@ -119,7 +119,7 @@ import { HTTPStreamData } from "@/models/graphql/StreamData.interface";
 })
 export default class Landing extends Vue {
   carbonBranches: { id: string; name: string; branchid: string }[] = [];
-  branchData: { id: string; name: string; data: HTTPStreamData }[] = [];
+  branchData: { id: string; name: string; data: HTTPStreamDataParent }[] = [];
   token = "";
   itemsPerPage = 8;
   search = "";

--- a/src/views/utils/viewAssessmentUtils.ts
+++ b/src/views/utils/viewAssessmentUtils.ts
@@ -129,7 +129,6 @@ export async function loadStream(context: any, streamId: string) {
     streamId,
     branchData
   );
-  console.log("childrenData:", childrenData);
 
   const co2Data = extractCo2Data(branchData, childrenData);
 


### PR DESCRIPTION
pr to fix the bug where the a1-5 values shown do not add up to the "total carbon" value that was shown.

Issue was because we were using graphql to get the children objects from the report, but the graphql endpoint could only send back 100 children. Most models have more than 100 objects, so this was causing the error. The fix was to switch to using the http end points to get the report objects from speckle.

I also added a couple new interfaces to clean things up a little bit