### PR TITLE
Update production environment to not have authentication

### DIFF
--- a/.github/workflows/build-infra.yml
+++ b/.github/workflows/build-infra.yml
@@ -45,7 +45,7 @@ jobs:
             -var-file=${{ matrix. environment }}.tfvars \
             -var="azure_app_client_secret=${{ secrets.STATIC_PAGES_CLIENT_SECRET }}" \
             -var="private_key=${{ secrets.STATIC_PAGES_PRIVATE_KEY }}" \
-            -var="public_key=${{ secrets.STATIC_PAGES_PUBLIC_KEY }}"
+            -var="public_key=${{ secrets.STATIC_PAGES_PUBLIC_KEY }}" 
 
 
       - name: Build Infrastructure

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -19,4 +19,5 @@ module "static_site" {
   redirect_uri = var.redirect_uri
   environment = var.environment
   project_name = "a-carbon-tool"
+  make_public_with_no_auth = var.make_public_with_no_auth
 }

--- a/infra/production.tfvars
+++ b/infra/production.tfvars
@@ -3,3 +3,4 @@ redirect_uri="https://act.speckle.arup.com/_callback"
 project_name="a-carbon-tool"
 environment = "prod"
 domain = "speckle.arup.com"
+make_public_with_no_auth=true

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -38,3 +38,9 @@ variable "domain" {
   type = string
   description = "base domain already configured in route 53"
 }
+
+variable "make_public_with_no_auth" {
+  type = string
+  description = "make this site open to the internet"
+  default = false
+}


### PR DESCRIPTION
This will make the production site completely public. There will be no authentication with Azure AD