### PR TITLE
fixed issue with material total values

### DIFF
--- a/src/components/viewAssessment/MaterialBreakdownCard.vue
+++ b/src/components/viewAssessment/MaterialBreakdownCard.vue
@@ -26,7 +26,7 @@ export default class MaterialBreakdownCard extends Vue {
   get chartData(): ChartData[] {
     return this.materials.map((m) => ({
       label: m.label,
-      value: m.value,
+      value: Math.round(m.value),
       color: m.color,
     }));
   }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -53,7 +53,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    version: "0.11.1 \u00DF",
+    version: "0.11.2 \u00DF",
     speckleFolderName: "actcarbonreport",
     speckleViewer: {
       viewer: undefined,

--- a/src/views/Assessment.vue
+++ b/src/views/Assessment.vue
@@ -787,7 +787,7 @@ export default class Assessment extends Vue {
       A1A3 += rd.productStageCarbonA1A3;
       A4 += rd.transportCarbonA4;
       A5Waste += rd.constructionCarbonA5.waste;
-      const objTotal = A1A3 + A4 + A5Waste;
+      const objTotal = rd.productStageCarbonA1A3 + rd.transportCarbonA4 + rd.constructionCarbonA5.waste;
       const materialName = o.formData.material.name;
       if (materialName in materialsObj) {
         materialsObj[materialName].value += objTotal;


### PR DESCRIPTION
Fixed an issue that Gillian brought up last Friday. Was to do with the material breakdown graph not looking right. Turned out that the calculation for finding the total carbon for each object was wrong, this pr fixes that.

Haven't included any bug fix message as this feels too small to need one.