### PR TITLE
Rw/bug/model saving

### DIFF
--- a/src/components/core/VersionUpdateDialog.vue
+++ b/src/components/core/VersionUpdateDialog.vue
@@ -60,8 +60,8 @@ export default class VersionUpdateDialog extends Vue {
 
   fixes: { title: string; subtitle: string }[] = [
     {
-      title: "Fixed bug in A5 calculations",
-      subtitle: "Fixed a bug causing very high A5 values in reports",
+      title: "Fixed bug in report models",
+      subtitle: "Fixed a bug that would cause some models to not be saved properly in reports",
     },
   ];
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -53,7 +53,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    version: "0.11.3 \u00DF",
+    version: "0.11.4 \u00DF",
     speckleFolderName: "actcarbonreport",
     speckleViewer: {
       viewer: undefined,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -495,7 +495,6 @@ export default new Vuex.Store({
     ) {
       if (newModel) {
         const combined = [newModel.parent, ...newModel.children];
-        console.log("newModel:", newModel);
 
         const combinedSplit: (IParamsParent | IChildObject)[][] = [];
         const batchSize = 100;
@@ -510,7 +509,7 @@ export default new Vuex.Store({
             formData.append(
               "batch1",
               new Blob([
-                JSON.stringify([c]),
+                JSON.stringify(c),
               ])
             );
             return fetch(

--- a/src/views/Assessment.vue
+++ b/src/views/Assessment.vue
@@ -234,7 +234,7 @@ export default class Assessment extends Vue {
     this.token = this.$store.state.token.token;
     this.transportTypes = this.$store.state.transportTypes;
     this.becs = this.$store.state.becs;
-    // AddParams.testRun(this.$store.state.selectedServer.url, this.token, [])
+    AddParams.testRun(this.$store.state.selectedServer.url, this.token, [])
     let { streamId, branchName } = this.$route.params;
     if (!streamId) streamId = this.modalStreamid;
     if (!branchName) branchName = this.modalBranchName;

--- a/src/views/Assessment.vue
+++ b/src/views/Assessment.vue
@@ -234,7 +234,6 @@ export default class Assessment extends Vue {
     this.token = this.$store.state.token.token;
     this.transportTypes = this.$store.state.transportTypes;
     this.becs = this.$store.state.becs;
-    AddParams.testRun(this.$store.state.selectedServer.url, this.token, [])
     let { streamId, branchName } = this.$route.params;
     if (!streamId) streamId = this.modalStreamid;
     if (!branchName) branchName = this.modalBranchName;

--- a/src/views/Assessment.vue
+++ b/src/views/Assessment.vue
@@ -787,7 +787,7 @@ export default class Assessment extends Vue {
       A1A3 += rd.productStageCarbonA1A3;
       A4 += rd.transportCarbonA4;
       A5Waste += rd.constructionCarbonA5.waste;
-      const objTotal = A1A3 + A4 + A5Waste;
+      const objTotal = rd.productStageCarbonA1A3 + rd.transportCarbonA4 + rd.constructionCarbonA5.waste;
       const materialName = o.formData.material.name;
       if (materialName in materialsObj) {
         materialsObj[materialName].value += objTotal;

--- a/src/views/Assessment.vue
+++ b/src/views/Assessment.vue
@@ -234,6 +234,7 @@ export default class Assessment extends Vue {
     this.token = this.$store.state.token.token;
     this.transportTypes = this.$store.state.transportTypes;
     this.becs = this.$store.state.becs;
+    // AddParams.testRun(this.$store.state.selectedServer.url, this.token, [])
     let { streamId, branchName } = this.$route.params;
     if (!streamId) streamId = this.modalStreamid;
     if (!branchName) branchName = this.modalBranchName;

--- a/src/views/utils/add-params/addParams.ts
+++ b/src/views/utils/add-params/addParams.ts
@@ -92,7 +92,6 @@ export interface AddParamsModel {
 }
 
 export async function testRun(url: string, token: string, params: ParamAdd[]) {
-  console.log("adding params");
   const streamid1 = "4a48b650af";
   const parentObjId = "e0965cb466f45fce6d949fb33f8992d7";
   const parent: IParamsParent = await fetch(
@@ -118,8 +117,6 @@ export async function testRun(url: string, token: string, params: ParamAdd[]) {
     );
   }
 
-  console.log("combinedSplit:", combinedSplit);
-
   await Promise.all(
     combinedSplit.map((c) => {
       const formData = new FormData();
@@ -134,8 +131,6 @@ export async function testRun(url: string, token: string, params: ParamAdd[]) {
       });
     })
   );
-
-  console.log("res:", res);
 }
 
 export async function addParams(

--- a/src/views/utils/add-params/addParams.ts
+++ b/src/views/utils/add-params/addParams.ts
@@ -92,7 +92,7 @@ export interface AddParamsModel {
 }
 
 export async function testRun(url: string, token: string, params: ParamAdd[]) {
-  console.log("adding params")
+  console.log("adding params");
   const streamid1 = "4a48b650af";
   const parentObjId = "e0965cb466f45fce6d949fb33f8992d7";
   const parent: IParamsParent = await fetch(
@@ -112,27 +112,28 @@ export async function testRun(url: string, token: string, params: ParamAdd[]) {
 
   const combinedSplit: (IParamsParent | IChildObject)[][] = [];
   const batchSize = 100;
-  for (let i = 0; i < combined.length; i+= batchSize) {
-    combinedSplit.push(combined.slice(i, Math.min(i + batchSize, combined.length)));
+  for (let i = 0; i < combined.length; i += batchSize) {
+    combinedSplit.push(
+      combined.slice(i, Math.min(i + batchSize, combined.length))
+    );
   }
 
   console.log("combinedSplit:", combinedSplit);
 
-  await Promise.all(combinedSplit.map((c) => {
-    const formData = new FormData();
-    formData.append(
-      "batch1",
-      new Blob([JSON.stringify(c)])
-    );
-    const streamid2 = "465e7157fe";
-    return fetch(`${url}/objects/${streamid2}`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      body: formData,
-    });
-  }))
+  await Promise.all(
+    combinedSplit.map((c) => {
+      const formData = new FormData();
+      formData.append("batch1", new Blob([JSON.stringify(c)]));
+      const streamid2 = "465e7157fe";
+      return fetch(`${url}/objects/${streamid2}`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        body: formData,
+      });
+    })
+  );
 
   console.log("res:", res);
 }

--- a/src/views/utils/add-params/addParams.ts
+++ b/src/views/utils/add-params/addParams.ts
@@ -205,13 +205,6 @@ export async function addParams(
   });
 
   // 4. create and update new parent object
-  // add new id
-  // const newParentObj: IParamsParent = {
-  //   ...parent,
-  //   id: newParentId,
-  // };
-
-  // update __closure to new child id's
   const newClosure: { [key: string]: number } = {};
   Object.entries(parent.__closure).forEach(([key, value]) => {
     if (idMapper[key]) {
@@ -223,19 +216,6 @@ export async function addParams(
   const newParentObj: IParamsParent = convertObj(parent, idMapper);
   newParentObj.id = newParentId;
   newParentObj.__closure = newClosure;
-  // newParentObj.__closure = newClosure;
-
-  // update all reference fields (fields that start with an @)
-  // Object.keys(newParentObj).forEach((key) => {
-  //   if (key.startsWith("@")) {
-  //     const records = newParentObj[key] as ReferenceObject[];
-  //     const newRecords = records.map((r) => ({
-  //       ...r,
-  //       referencedId: idMapper[r.referencedId],
-  //     }));
-  //     newParentObj[key] = newRecords;
-  //   }
-  // });
 
   return {
     parent: newParentObj,


### PR DESCRIPTION
noticed that Gillian's model wasn't saving properly for some reason. Turns out that it didn't look the same as a regular Revit model does when saved in Speckle.

Made a fix for that which I think has also helped us towards working better with non-Revit/Rhino softwares (although we still won't work fully with them, so can't recommend that users use anything but Revit/Rhino) and just generally made things a little nice on the model-saving side. Also changed up how the model is pushed up to hopefully make the model saving a little more stable (although I think that it does make things a little slower, but at this point it's due to resource limitations on the Arup Speckle server's end)

EDIT: 24/05/2023
Some models that were attempting to be uploaded were very large and were breaking the Arup Speckle server a bit when we were tyring to upload them. I've put in a temporary fix to stop this from happening (if a large batch is detected then we use a much smaller batch size and go slower to stop the server being under as much strain), but we will need to figure out a better fix.

The issue is basically because we're using [this endpoint](https://speckle.guide/dev/server-rest-api.html#:~:text=%23-,Upload%20a%20batch%20of%20objects,-URL%3A%20%24%7BCANONICAL_URL) to upload a batch of objects. That bit of the docs says that there's a limit of 10MB per object and 50MB total. The Gillian streams that were breaking the server didn't ever have batches that broke this. But it seems like the Arup server starts to have problems as soon as you get total batch sizes above 10MB.