### PR TITLE
Assessment page no streams

### DIFF
--- a/src/components/assessment/NoStreams.vue
+++ b/src/components/assessment/NoStreams.vue
@@ -1,16 +1,20 @@
 <template>
-  <v-container class="text-center">
-    <p>You have not been assigned to any streams.</p>
-    <p>
-      Please go to your selected server,
-      <a :href="serverUrl" target="_blank">{{ serverUrl }}</a>
-      , and either create a new stream or be added to an existing stream.
-    </p>
-    <p>
-      More info on how to use Speckle can be found at the
-      <a :href="SpeckleDocsUrl" target="_blank">Speckle docs</a>.
-    </p>
-  </v-container>
+  <div class="d-flex justify-center align-center" style="height: 70vh">
+    <v-card width="50%" class="text-center">
+      <v-card-text class="white--text">
+        <p>You have not been assigned to any streams.</p>
+        <p>
+          Please go to your selected server,
+          <a :href="serverUrl" target="_blank">{{ serverUrl }}</a>
+          , and either create a new stream or be added to an existing one.
+        </p>
+        <p>
+          For more information on how to use Speckle, please visit the
+          <a :href="SpeckleDocsUrl" target="_blank">Speckle docs</a>.
+        </p>
+      </v-card-text>
+    </v-card>
+  </div>
 </template>
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";

--- a/src/components/assessment/NoStreams.vue
+++ b/src/components/assessment/NoStreams.vue
@@ -1,0 +1,28 @@
+<template>
+  <v-container class="text-center">
+    <p>You have not been assigned to any streams.</p>
+    <p>
+      Please go to your selected server,
+      <a :href="serverUrl" target="_blank">{{ serverUrl }}</a>
+      , and either create a new stream or be added to an existing stream.
+    </p>
+    <p>
+      More info on how to use Speckle can be found at the
+      <a :href="SpeckleDocsUrl" target="_blank">Speckle docs</a>.
+    </p>
+  </v-container>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop } from "vue-property-decorator";
+
+@Component
+export default class NoStreams extends Vue {
+  @Prop() serverUrl!: string;
+
+  get SpeckleDocsUrl() {
+    return this.serverUrl.includes("arup")
+      ? "https://speckle.arup.com/tutorials/get_started.html"
+      : "https://speckle.guide/";
+  }
+}
+</script>

--- a/src/components/core/VersionUpdateDialog.vue
+++ b/src/components/core/VersionUpdateDialog.vue
@@ -56,24 +56,13 @@ export default class VersionUpdateDialog extends Vue {
   @Prop() dialog!: boolean;
   @Prop() version!: string;
 
-  features: { title: string; subtitle: string }[] = [
-    {
-      title: "Material buildup",
-      subtitle:
-        "Objects in assessments can now have multiple materials assigned to them, allowing for material buildups to be used instead of single materials",
-    },
-    {
-      title: "Grouping filters update",
-      subtitle:
-        "Grouping filters that require it now have an 'undefined' field, meaning that a filter will not need to appear on every object to allow it to be used for object grouping",
-    },
-  ];
+  features: { title: string; subtitle: string }[] = [];
 
   fixes: { title: string; subtitle: string }[] = [
     {
-      title: "Large models bug",
+      title: "Assessment page bug",
       subtitle:
-        "Fixed a bug causing an 'out of memory' error to sometimes occur when loading large models",
+        "Fixed a bug leading to the assessment page not showing anything when a user is not assigned to any Speckle streams",
     },
   ];
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -53,7 +53,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    version: "0.12.2 \u00DF",
+    version: "0.12.3 \u00DF",
     speckleFolderName: "actcarbonreport",
     speckleViewer: {
       viewer: undefined,

--- a/src/views/Assessment.vue
+++ b/src/views/Assessment.vue
@@ -2,7 +2,7 @@
   <v-main>
     <loading-spinner v-if="loading" :text="loadingSpinnerText" />
     <v-container
-      v-else
+      v-else-if="availableStreams.length !== 0"
       fluid
       class="d-flex justify-flex-start flex-row"
       style="margin: 10px; padding: 10px; width: 100%"
@@ -59,6 +59,7 @@
         :loadingBar="false"
       />
     </v-container>
+    <NoStreams :serverUrl="$store.state.selectedServer.url" v-else />
     <new-branch-dialog
       :dialog="newBranchDialog"
       :branchNames="branchNames"
@@ -88,6 +89,7 @@ import * as AddParams from "./utils/add-params/addParams";
 import AssessmentStepper from "@/components/assessment/AssessmentStepper.vue";
 import SESnackBar from "@/components/shared/SESnackBar.vue";
 import NewBranchDialog from "@/components/assessment/NewBranchDialog.vue";
+import NoStreams from "@/components/assessment/NoStreams.vue";
 
 import { findStringProps } from "./utils/propertyFiltering";
 
@@ -140,6 +142,7 @@ interface AvailableStream {
     SESnackBar,
     NewBranchDialog,
     LoadingSpinner,
+    NoStreams,
   },
 })
 export default class Assessment extends Vue {


### PR DESCRIPTION
Seems to be the first comment we get from basically everyone is that the "assessment page is just blank". Typically this is just because the user has not been added to any streams. Added in a check for this, and if the user is not added to any streams then a message appears telling the user to add themselves to a stream.

Very quick fix, probably some issues with the wording (happy to make any changes to that). Probably also a better way that we could handle this, but I think that this should work for now.

Screenshot of the message:
![no streams message](https://github.com/arup-group/a-carbon-tool/assets/43271984/5517cfee-d4c7-483c-abc9-a3a4297d0daf)

Added in a small bit that makes it so that if the user is on an arup server (just checked by seeing if `arup` is in the url) then the user will be linked to the Arup Speckle docs, otherwise they will be linked to the general Speckle docs.