### PR TITLE
login redirect

### DIFF
--- a/src/components/shared/ErrorRetry.vue
+++ b/src/components/shared/ErrorRetry.vue
@@ -1,14 +1,25 @@
 <template>
   <div class="d-flex align-center flex-column" style="width: 100%">
     <p>Error</p>
+    <p v-if="errorMessage">{{ errorMessage }}</p>
     <v-btn color="primary" style="color: black" @click="retry">Retry</v-btn>
+    <template v-if="!isDashboard">
+      <p class="mt-4">or</p>
+      <v-btn color="primary" style="color: black" href="/">Return to dashboard</v-btn>
+    </template>
   </div>
 </template>
 <script lang="ts">
-import { Vue, Component, Emit } from "vue-property-decorator";
+import { Vue, Component, Prop, Emit } from "vue-property-decorator";
 
 @Component
 export default class ErrorRetry extends Vue {
+  @Prop() errorMessage!: string;
+
+  get isDashboard() {
+    return this.$route.name === "Landing";
+  }
+
   @Emit("retry")
   retry() {
     return;

--- a/src/components/shared/LoadingContainer.vue
+++ b/src/components/shared/LoadingContainer.vue
@@ -12,11 +12,11 @@
         color="primary"
       ></v-progress-linear>
     </div>
-    <error-retry v-else @retry="retry" />
+    <error-retry v-else :errorMessage="errorMessage" @retry="retry" />
   </div>
 </template>
 <script lang="ts">
-import { Vue, Component, Prop, Emit, Watch } from "vue-property-decorator";
+import { Vue, Component, Prop, Emit } from "vue-property-decorator";
 import LoadingSpinner from "./LoadingSpinner.vue";
 import ErrorRetry from "./ErrorRetry.vue";
 
@@ -26,6 +26,7 @@ import ErrorRetry from "./ErrorRetry.vue";
 export default class LoadingContainer extends Vue {
   @Prop() loading!: boolean;
   @Prop() error!: boolean;
+  @Prop() errorMessage!: string;
   @Prop() line!: boolean;
 
   get loaded() {

--- a/src/components/viewAssessment/ChangeServerDialog.vue
+++ b/src/components/viewAssessment/ChangeServerDialog.vue
@@ -23,7 +23,7 @@
         </div>
       </v-card-text>
       <v-card-actions class="d-flex justify-end">
-        <v-btn @click="toDashboard">Back to dashboard</v-btn>
+        <v-btn href="/">Back to dashboard</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -45,11 +45,6 @@ export default class ChangeServerDialog extends Vue {
   @Emit("attemptLogin")
   attemptLogin() {
     return this.reportServer;
-  }
-
-  @Emit("toDashboard")
-  toDashboard() {
-    return;
   }
 }
 </script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -114,6 +114,11 @@ router.beforeEach(async (to, from, next) => {
               next();
             }
           }
+          else {
+            if (to.fullPath !== "/") {
+              localStorage.setItem("redirect-path", to.fullPath);
+            }
+          }
           next("/login");
         } else next("/");
       }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -53,7 +53,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    version: "0.13.0 \u00DF",
+    version: "0.13.1 \u00DF",
     speckleFolderName: "actcarbonreport",
     speckleViewer: {
       viewer: undefined,

--- a/src/views/StreamReports.vue
+++ b/src/views/StreamReports.vue
@@ -2,7 +2,7 @@
   <v-main class="mr-7 ml-7 pb-4">
     <loading-container
       :error="error"
-      errorMessage="Stream not found, make sure you are signed into the correct server"
+      errorMessage="Stream not found. Please make sure you are signed into the correct server."
       :loading="loading"
       @retry="loadStreams"
     >

--- a/src/views/StreamReports.vue
+++ b/src/views/StreamReports.vue
@@ -1,6 +1,11 @@
 <template>
   <v-main class="mr-7 ml-7 pb-4">
-    <loading-container :error="error" :loading="loading" @retry="loadStreams">
+    <loading-container
+      :error="error"
+      errorMessage="Stream not found, make sure you are signed into the correct server"
+      :loading="loading"
+      @retry="loadStreams"
+    >
       <template v-slot="{ loaded }">
         <v-container v-if="loaded">
           <v-data-iterator
@@ -192,9 +197,7 @@ export default class StreamReports extends Vue {
     // this.quickBranchName = branchName;
     // this.quickReport = true;
     // this.$router.push({ name: "UpdateAssessmentBranch"})
-    this.$router.push(
-      `assessment/${this.streamid}/${branchName}`
-    );
+    this.$router.push(`assessment/${this.streamid}/${branchName}`);
   }
   quickReportClose() {
     this.quickReport = false;
@@ -258,7 +261,8 @@ export default class StreamReports extends Vue {
       } else {
         this.snackTimeout = 30000;
         this.deleteSuccess = false;
-        this.deleteSnackTextError = "Something went wrong:" + deleted.errors[0].message;
+        this.deleteSnackTextError =
+          "Something went wrong:" + deleted.errors[0].message;
         this.deleteSnack = true;
       }
     } catch (err) {

--- a/src/views/ViewAssessment.vue
+++ b/src/views/ViewAssessment.vue
@@ -55,7 +55,6 @@
       :reportServer="reportServer"
       @close="closeChangeServerDialog"
       @attemptLogin="attemptLogin"
-      @toDashboard="toDashboard"
     />
   </v-main>
 </template>
@@ -190,9 +189,6 @@ export default class ViewAssessment extends Vue {
 
   back() {
     this.$router.push(`/${this.streamId}`);
-  }
-  toDashboard() {
-    this.$router.push("/");
   }
 
   async loadReport() {


### PR DESCRIPTION
Changed the login so that if you're going to a specific page (eg `/assessment`) you will be redirected to the login page, then once you've logged in you'll be redirected back to where you were trying to go. The idea was to be similar to how a lot of other sites work.

Also involved making a small update to stream reports page as if someone goes to, for example `/b13799ec6e` (a stream on the xyz server), but then sign into the Arup server, they'll be redirected to `/b13799ec6e` and get an error as the stream won't be able to be found. Changed the error message on that page to include a message saying "Stream not found, make sure you are signed into the correct server" and a link back to the dashboard.

Also made sure that this hasn't broken any of the report sharing links.

To test:
1. Log out
2. Go to some route like `/assessment` or `/465e7157fe`
3. Sign in
4. (Hopefully) be redirected